### PR TITLE
Upsert synchronously (wait for record to become resolvable)

### DIFF
--- a/lib/vagrant-aws-dns/action/add_record.rb
+++ b/lib/vagrant-aws-dns/action/add_record.rb
@@ -8,8 +8,9 @@ module VagrantPlugins
 
         def call(env)
           super env do |hosted_zone_id, record, type, value|
+            @machine.ui.info("Configuring DNS record...")
             @aws.add_record(hosted_zone_id, record, type, value)
-            @machine.ui.info("Add dns record #{record} pointing to #{value}.")
+            @machine.ui.info("Updated DNS record #{record} to point to #{value}.")
           end
         end
 

--- a/lib/vagrant-aws-dns/util/aws_util.rb
+++ b/lib/vagrant-aws-dns/util/aws_util.rb
@@ -33,7 +33,8 @@ module VagrantPlugins
         end
 
         def add_record(hosted_zone_id, record, type, value)
-          change_record(hosted_zone_id, record, type, value, 'UPSERT')
+          change = change_record(hosted_zone_id, record, type, value, 'UPSERT')
+          wait_for_change(change)
         end
 
         def remove_record(hosted_zone_id, record, type, value)
@@ -63,6 +64,10 @@ module VagrantPlugins
                 ]
               }
           })
+        end
+
+        def wait_for_change(change_response)
+          @route53.wait_until(:resource_record_sets_changed, id: change_response.change_info.id)
         end
       end
     end


### PR DESCRIPTION
This can be a deal-breaker in some multi-machine provisioning scenarios where one machine needs to access another by its DNS name almost immediately.

Not sure if the wait needs to be optional as it's only about 20-30 seconds in most cases, so I just chose the simple way.